### PR TITLE
fixed jasmine.DEFAULT_TIMEOUT_INTERVAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ process.on('unhandledRejection', (reason, p) => {
 
 var Jasmine = require('jasmine');
 var jasmine = new Jasmine();
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
+jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
 jasmine.loadConfigFile('./spec/support/jasmine.json');
 jasmine.configureDefaultReporter({
   showColors: true


### PR DESCRIPTION
reference `jasmine.DEFAULT_TIMEOUT_INTERVAL` was wrong it's `jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL`
https://www.npmjs.com/package/jasmine-console-reporter#full-example-with-jasmine-nodejs